### PR TITLE
Reverse changelog (newest first)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,24 @@
-### 0.0.1 (04/17/2024)
-* initial version
+### 0.3.3 (10/25/2024)
+* feature: import configs with texture files
+* feature: add custom layer with custom texture
+* enhance: dispose layer ability
 
-### 0.0.2 (04/17/2024)
-* add some method and class documentations
-* remove platforms section in pubs-pecs
-* remove platform classes and tests
-* add pub-ignores
+### 0.3.2 (10/15/2024)
+* feature: new particle editor
+* enhance: add automate publish
+* fixbugs: wrong particles count of limit-time layers
+* fixbugs: wrong afew particles count
 
-### 0.0.3 (04/18/2024)
-* add some method and class documentations
-* follow format suggestions
+### 0.2.5 (06/12/2024)
+* add automate publish
 
-### 0.0.4 (04/18/2024)
-* fix example image flicking
-* follow format suggestions
-* rich instruction
+### 0.2.2 (05/23/2024)
+* fixbugs: handle low number particles
 
-### 0.0.5 (04/19/2024)
-* fix instruction problem
-* add more symbol comments
-
-### 0.1.0 (04/26/2024)
-* feature: add editor (initial version)
-* enhance: replace blending functions
-* enhance: limited time particle
-* fixbugs: resize image rects on texture changes
+### 0.2.1 (05/03/2024)
+* feature: multilayer particles support
+* enhance: use mutual emitters for increase performance
+* cleanups: better code instructions
 
 ### 0.2.0 (05/01/2024)
 * feature: support finite and infinite particles
@@ -33,24 +27,30 @@
 * feature: new editor theme
 * enhance: better ux for inputs
 
-### 0.2.1 (05/03/2024)
-* feature: multilayer particles support
-* enhance: use mutual emitters for increase performance
-* cleanups: better code instructions
+### 0.1.0 (04/26/2024)
+* feature: add editor (initial version)
+* enhance: replace blending functions
+* enhance: limited time particle
+* fixbugs: resize image rects on texture changes
 
-### 0.2.2 (05/23/2024)
-* fixbugs: handle low number particles
+### 0.0.5 (04/19/2024)
+* fix instruction problem
+* add more symbol comments
 
-### 0.2.5 (06/12/2024)
-* add automate publish
+### 0.0.4 (04/18/2024)
+* fix example image flicking
+* follow format suggestions
+* rich instruction
 
-### 0.3.2 (10/15/2024)
-* feature: new particle editor
-* enhance: add automate publish
-* fixbugs: wrong particles count of limit-time layers
-* fixbugs: wrong afew particles count
+### 0.0.3 (04/18/2024)
+* add some method and class documentations
+* follow format suggestions
 
-### 0.3.3 (10/25/2024)
-* feature: import configs with texture files
-* feature: add custom layer with custom texture
-* enhance: dispose layer ability
+### 0.0.2 (04/17/2024)
+* add some method and class documentations
+* remove platforms section in pubs-pecs
+* remove platform classes and tests
+* add pub-ignores
+
+### 0.0.1 (04/17/2024)
+* initial version


### PR DESCRIPTION
I just reversed the changelog. 
Based on [the convention](https://keepachangelog.com/en/1.1.0/), it should be descending.